### PR TITLE
[CMSO-1430] Throw exceptions instead of just logging errors.

### DIFF
--- a/src/Commands/ActivateCommand.php
+++ b/src/Commands/ActivateCommand.php
@@ -7,6 +7,7 @@ use Pantheon\Terminus\Request\RequestAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 use Pantheon\TerminusAutopilot\AutopilotApi\AutopilotClientAwareTrait;
+use Pantheon\Terminus\Exceptions\TerminusException;
 
 /**
  * Class ActivateCommand.
@@ -38,11 +39,10 @@ class ActivateCommand extends TerminusCommand implements RequestAwareInterface, 
         try {
             $this->getClient()->activate($site->id);
         } catch (\Throwable $t) {
-            $this->log()->error(
+            throw new TerminusException(
                 'Error activating Autopilot: {error_message}',
                 ['error_message' => $t->getMessage()]
             );
-            return;
         }
 
         $this->log()->success('Autopilot is activated.');

--- a/src/Commands/DeactivateCommand.php
+++ b/src/Commands/DeactivateCommand.php
@@ -7,6 +7,7 @@ use Pantheon\Terminus\Request\RequestAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 use Pantheon\TerminusAutopilot\AutopilotApi\AutopilotClientAwareTrait;
+use Pantheon\Terminus\Exceptions\TerminusException;
 
 /**
  * Class DeactivateCommand.
@@ -38,11 +39,10 @@ class DeactivateCommand extends TerminusCommand implements RequestAwareInterface
         try {
             $this->getClient()->deactivate($site->id);
         } catch (\Throwable $t) {
-            $this->log()->error(
+            throw new TerminusException(
                 'Error deactivating Autopilot: {error_message}',
                 ['error_message' => $t->getMessage()]
             );
-            return;
         }
 
         $this->log()->success('Autopilot is deactivated.');

--- a/src/Commands/DestinationCommand.php
+++ b/src/Commands/DestinationCommand.php
@@ -7,6 +7,7 @@ use Pantheon\Terminus\Request\RequestAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 use Pantheon\TerminusAutopilot\AutopilotApi\AutopilotClientAwareTrait;
+use Pantheon\Terminus\Exceptions\TerminusException;
 
 /**
  * Class DestinationSetCommand.
@@ -50,11 +51,10 @@ class DestinationCommand extends TerminusCommand implements RequestAwareInterfac
         try {
             $this->getClient()->setDestination($site->id, $destination);
         } catch (\Throwable $t) {
-            $this->log()->error(
+            throw new TerminusException(
                 'Error setting deployment destination: {error_message}',
                 ['error_message' => $t->getMessage()]
             );
-            return null;
         }
 
         $this->log()->success(

--- a/src/Commands/EnvSyncingCommand.php
+++ b/src/Commands/EnvSyncingCommand.php
@@ -7,6 +7,7 @@ use Pantheon\Terminus\Request\RequestAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 use Pantheon\TerminusAutopilot\AutopilotApi\AutopilotClientAwareTrait;
+use Pantheon\Terminus\Exceptions\TerminusException;
 
 /**
  * Class EnvSyncingCommand.
@@ -70,11 +71,10 @@ class EnvSyncingCommand extends TerminusCommand implements RequestAwareInterface
         try {
             $this->getClient()->setEnvSyncing($site->id, true);
         } catch (\Throwable $t) {
-            $this->log()->error(
+            throw new TerminusException(
                 'Error enabling environment syncing: {error_message}',
                 ['error_message' => $t->getMessage()]
             );
-            return;
         }
 
         $this->log()->success('Autopilot environment syncing is enabled.');
@@ -104,11 +104,10 @@ class EnvSyncingCommand extends TerminusCommand implements RequestAwareInterface
         try {
             $this->getClient()->setEnvSyncing($site->id, false);
         } catch (\Throwable $t) {
-            $this->log()->error(
+            throw new TerminusException(
                 'Error disabling environment syncing: {error_message}',
                 ['error_message' => $t->getMessage()]
             );
-            return;
         }
 
         $this->log()->success('Autopilot environment syncing is disabled.');

--- a/src/Commands/FrequencyCommand.php
+++ b/src/Commands/FrequencyCommand.php
@@ -7,6 +7,7 @@ use Pantheon\Terminus\Request\RequestAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 use Pantheon\TerminusAutopilot\AutopilotApi\AutopilotClientAwareTrait;
+use Pantheon\Terminus\Exceptions\TerminusException;
 
 /**
  * Class FrequencyCommand.
@@ -50,11 +51,10 @@ class FrequencyCommand extends TerminusCommand implements RequestAwareInterface,
         try {
             $this->getClient()->setFrequency($site->id, $frequency);
         } catch (\Throwable $t) {
-            $this->log()->error(
+            throw new TerminusException(
                 'Error updating frequency: {error_message}',
                 ['error_message' => $t->getMessage()]
             );
-            return null;
         }
 
         $this->log()->success(


### PR DESCRIPTION
Before:

```
terminus ap-activate <site>
 [error]  Error activating Autopilot: Autopilot cannot be activated. It has already been activated for this site.
kporras07@Kevins-MacBook-Pro.local ➜  ~  echo $?
0
```

After:

```
terminus ap-activate <site>
 [error]  Error activating Autopilot: Autopilot cannot be activated. It has already been activated for this site.

kporras07@Kevins-MacBook-Pro.local ➜  ~  echo $?
1
```