### PR TITLE
Allow "none" as an option to be set by deployment-destination

### DIFF
--- a/src/AutopilotApi/Client.php
+++ b/src/AutopilotApi/Client.php
@@ -255,6 +255,7 @@ class Client
             'dev',
             'test',
             'live',
+            'none',
         ];
     }
 

--- a/src/Commands/DestinationCommand.php
+++ b/src/Commands/DestinationCommand.php
@@ -31,7 +31,7 @@ class DestinationCommand extends TerminusCommand implements RequestAwareInterfac
      *
      * @param string $site_id Site name
      * @param string|null $destination The deployment destination environment.
-     *   Available options: dev, test, live.
+     *   Available options: dev, test, live, none.
      *
      * @return string|null
      *


### PR DESCRIPTION
You can set the deployment destination on the dashboard to "Do not deploy"

<img width="930" alt="Screenshot 2025-01-30 at 12 08 06 PM" src="https://github.com/user-attachments/assets/734e778c-818c-48f0-80a7-40b6b5a6d112" />

but the only options allowed via the `site:autopilot:deployment-destination` command are "dev", "test", and "live". I believe "none" is also a valid option, since that's what you see if you've set the destination to "Do not deploy" via the ui:

```
$ terminus site:autopilot:deployment-destination <no-destination-site>
none
```

Usage is this:
```
terminus site:autopilot:deployment-destination <site> none
```

Not sure if this option was left off for a good reason, but it's handy for my purposes!