### PR TITLE
Allow "none" as an option to be set by deployment-destination

### DIFF
--- a/.github/e2e.sh
+++ b/.github/e2e.sh
@@ -51,6 +51,7 @@ terminus site:autopilot:frequency "${SITENAME}" monthly
 
 echo "Setting Deployment Destination"
 terminus site:autopilot:deployment-destination "${SITENAME}" test
+terminus site:autopilot:deployment-destination "${SITENAME}" none
 
 echo "Deactivating Autopilot"
 terminus site:autopilot:deactivate "${SITENAME}"

--- a/src/AutopilotApi/Client.php
+++ b/src/AutopilotApi/Client.php
@@ -255,6 +255,7 @@ class Client
             'dev',
             'test',
             'live',
+            'none',
         ];
     }
 

--- a/src/Commands/DestinationCommand.php
+++ b/src/Commands/DestinationCommand.php
@@ -31,7 +31,7 @@ class DestinationCommand extends TerminusCommand implements RequestAwareInterfac
      *
      * @param string $site_id Site name
      * @param string|null $destination The deployment destination environment.
-     *   Available options: dev, test, live.
+     *   Available options: dev, test, live, none.
      *
      * @return string|null
      *


### PR DESCRIPTION
Replaces #36 to add test + trigger CI from a branch
Co-authored-by: Thinkshout Automation <ci-bot@thinkshout.com>
Co-authored-by: Maria Fisher <mariacha@gmail.com>